### PR TITLE
replaced corpus literals by variables

### DIFF
--- a/R/oppose.R
+++ b/R/oppose.R
@@ -1,6 +1,5 @@
 
 
-
 ##############################################################################
 # this is simply the Oppose script put into function(){ }
 
@@ -454,13 +453,13 @@ draw.polygons = function(summary.zeta.scores) {
 ############################################################################
 #
 # retrieving the names of samples
-filenames.primary.set = list.files("primary_set")
-filenames.secondary.set = list.files("secondary_set")
+filenames.primary.set = list.files(primary.corpus.dir)
+filenames.secondary.set = list.files(secondary.corpus.dir)
 #
 #
 # loading the primary set from text files
 corpus.of.primary.set = list()
-setwd("primary_set")
+setwd(primary.corpus.dir)
   for (file in filenames.primary.set) {
   # loading the next file from the list filenames.primary.set,
   current.file = tolower(scan(file,what="char",sep="\n",quiet=T))
@@ -480,7 +479,7 @@ setwd("..")
 
 # loading the secondary set from text files
 corpus.of.secondary.set = list()
-setwd("secondary_set")
+setwd(secondary.corpus.dir)
   for (file in filenames.secondary.set) {
   # loading the next file from the list filenames.secondary.set,
   current.file = tolower(scan(file,what="char",sep="\n",quiet=T))


### PR DESCRIPTION
Hi Maciej,

I'm doing some computational stylistics during the holidays...

The oppose script didn't use the primary.corpus.dir and secondary.corpus.dir variables.

Also, when using the chi-square zeta, the words_avoided and words_preferred files contain zeta values(?) rather than words. But that's too complicated for me to fix right now. 

I don't read my Huygens mail at the moment, but I do follow pboot@xs4all.nl.

Best,
Peter
