### PR TITLE
Encoding

### DIFF
--- a/R/gui.classify.R
+++ b/R/gui.classify.R
@@ -141,9 +141,9 @@ show.features = variables$show.features
 # a not very elegant way of switching from strings into logical values
 encoding.orig = variables$encoding
   if(variables$encoding == "UTF-8") {
-    encoding = TRUE
-  } else {
     encoding = FALSE
+  } else {
+    encoding = TRUE
   }
 
 
@@ -392,7 +392,7 @@ encoding.orig = variables$encoding
   entrylabel_SPA <- tklabel(f1,text="    Spanish     ")
   entrylabel_CJK <- tklabel(f1,text="      CJK       ")
   entrylabel_OTH <- tklabel(f1,text="     Other      ")
-  entrylabel_UTF <- tklabel(f1,text="     UTF-8      ")
+  entrylabel_UTF <- tklabel(f1,text="     Native encoding      ")
 
   #
   tkgrid(tklabel(f1,text="LANGUAGE: "),entrylabel_ENG,entrylabel_EN2,entrylabel_EN3,entrylabel_LAT,entrylabel_LA2)
@@ -418,7 +418,7 @@ encoding.orig = variables$encoding
   tk2tip(entrylabel_SPA, "Plain Castilian: contractions and \ncompound words are split")
   tk2tip(entrylabel_CJK, "Chinese, Japanese and Korean \n(experimental)")
   tk2tip(entrylabel_OTH, "Other language than the ones listed above.")
-  tk2tip(entrylabel_UTF, "Check this box if your texts are in Unicode \nand your system is Windows;\nno need to bother if you use Linux of Mac")
+  tk2tip(entrylabel_UTF, "Check this box if your texts are in a \nnative encoding other than UTF-8. \n(May apply on Windows machines.) \nUse the function check_encoding() \nif you are uncertain.")
 
   
   # next row: TEXT FEATURES
@@ -816,7 +816,7 @@ encoding.orig = variables$encoding
 
 
   # switching back from logical values into strings
-  if(variables$encoding == TRUE) {
+  if(variables$encoding == FALSE) {
     variables$encoding = "UTF-8"
   } else {
     variables$encoding = "native.enc"

--- a/R/gui.oppose.R
+++ b/R/gui.oppose.R
@@ -160,9 +160,9 @@ plot.token = variables$plot.token
 # a not very elegant way of switching from strings into logical values
 encoding.orig = variables$encoding
   if(variables$encoding == "UTF-8") {
-    encoding = TRUE
-  } else {
     encoding = FALSE
+  } else {
+    encoding = TRUE
   }
 
 
@@ -331,7 +331,7 @@ tkgrid(tklabel(tt,text="    ")) # blank line
 variables$encoding = encoding  
 
   # switching back from logical values into strings
-  if(variables$encoding == TRUE) {
+  if(variables$encoding == FALSE) {
     variables$encoding = "UTF-8"
   } else {
     variables$encoding = "native.enc"

--- a/R/gui.stylo.R
+++ b/R/gui.stylo.R
@@ -139,9 +139,9 @@ z.scores.of.all.samples = variables$z.scores.of.all.samples
 # a not very elegant way of switching from strings into logical values
 encoding.orig = variables$encoding
   if(variables$encoding == "UTF-8") {
-    encoding = TRUE
+    encoding = FALSE #TRUE
   } else {
-    encoding = FALSE
+    encoding = TRUE #FALSE
   }
 
 
@@ -404,7 +404,7 @@ encoding.orig = variables$encoding
   entrylabel_SPA <- tklabel(f1,text="    Spanish     ")
   entrylabel_CJK <- tklabel(f1,text="      CJK       ")
   entrylabel_OTH <- tklabel(f1,text="     Other      ")
-  entrylabel_UTF <- tklabel(f1,text="     UTF-8      ")
+  entrylabel_UTF <- tklabel(f1,text="     native encoding      ")
 
   #
   tkgrid(tklabel(f1,text="LANGUAGE: "),entrylabel_ENG,entrylabel_EN2,entrylabel_EN3,entrylabel_LAT,entrylabel_LA2)
@@ -432,7 +432,7 @@ encoding.orig = variables$encoding
   tk2tip(entrylabel_SPA, "Plain Castilian: contractions and \ncompound words are split")
   tk2tip(entrylabel_CJK, "Chinese, Japanese and Korean \n(experimental)")
   tk2tip(entrylabel_OTH, "Other language than the ones listed above.")
-  tk2tip(entrylabel_UTF, "Check this box if your texts are in Unicode \nand your system is Windows;\nno need to bother if you use Linux of Mac")
+  tk2tip(entrylabel_UTF, "Check this box if your texts are in a \nnative encoding other than UTF-8. \n(May apply on Windows machines.) \nUse the function check_encoding() \nif you are uncertain.")
 
   
   
@@ -874,7 +874,7 @@ encoding.orig = variables$encoding
 
 
   # switching back from logical values into strings
-  if(variables$encoding == TRUE) {
+  if(variables$encoding == FALSE) { #TRUE) {
     variables$encoding = "UTF-8"
   } else {
     variables$encoding = "native.enc"

--- a/R/gui.stylo.R
+++ b/R/gui.stylo.R
@@ -139,9 +139,9 @@ z.scores.of.all.samples = variables$z.scores.of.all.samples
 # a not very elegant way of switching from strings into logical values
 encoding.orig = variables$encoding
   if(variables$encoding == "UTF-8") {
-    encoding = FALSE #TRUE
+    encoding = FALSE
   } else {
-    encoding = TRUE #FALSE
+    encoding = TRUE
   }
 
 
@@ -404,7 +404,7 @@ encoding.orig = variables$encoding
   entrylabel_SPA <- tklabel(f1,text="    Spanish     ")
   entrylabel_CJK <- tklabel(f1,text="      CJK       ")
   entrylabel_OTH <- tklabel(f1,text="     Other      ")
-  entrylabel_UTF <- tklabel(f1,text="     native encoding      ")
+  entrylabel_UTF <- tklabel(f1,text="     Native encoding      ")
 
   #
   tkgrid(tklabel(f1,text="LANGUAGE: "),entrylabel_ENG,entrylabel_EN2,entrylabel_EN3,entrylabel_LAT,entrylabel_LA2)
@@ -874,7 +874,7 @@ encoding.orig = variables$encoding
 
 
   # switching back from logical values into strings
-  if(variables$encoding == FALSE) { #TRUE) {
+  if(variables$encoding == FALSE) {
     variables$encoding = "UTF-8"
   } else {
     variables$encoding = "native.enc"

--- a/R/stylo.default.settings.R
+++ b/R/stylo.default.settings.R
@@ -87,7 +87,7 @@ stop.words = NULL
 analyzed.features = "w"
 ngram.size = 1
 preserve.case = FALSE
-encoding = "native.enc"
+encoding = "UTF-8"
 
 
 # some classifiers, e.g. Nearest Shrunken Centroids, allows you to 


### PR DESCRIPTION
Hi Maciej,

now default encoding should finally be UTF-8, even in the stylo- and classify-GUIs. I also changed the settings in gui.oppose.R, but realized they do nothing there, because there is no UTF-8 button anyway (though all the code handling the variable). 

All the best,
Steffen