### PR TITLE
Implement much faster approach to building corpus wordlist in stylo()

### DIFF
--- a/R/stylo.R
+++ b/R/stylo.R
@@ -661,17 +661,7 @@ if(exists("frequencies.0.culling") == FALSE) {
     mfw.list.of.all = features
   } else {
     # Extracting all the words used in the corpus
-    wordlist.of.loaded.corpus = c()
-#wordlist.of.loaded.corpus = unlist(loaded.corpus)
-    for (file in 1 : length(loaded.corpus)) {
-      # loading the next sample from the list "corpus.filenames"
-      current.text = loaded.corpus[[file]]
-      # putting the files together:
-      wordlist.of.loaded.corpus = c(wordlist.of.loaded.corpus, current.text)
-      # short message on screen
-      message(".", appendLF = FALSE)
-      if(file/25 == floor(file/25)) { message("")} # a newline every 25th sample
-    }
+    wordlist.of.loaded.corpus = unlist(loaded.corpus, use.names = FALSE)
 
     # Preparing a sorted frequency list of the whole primary set (or both sets).
     # short message


### PR DESCRIPTION
Address #32 

This section of the function generates a list of every token in the corpus. The old approach uses variable reassignment to grow `wordlist.of.loaded.corpus`. This approach is quite slow, especially when handling large corpuses. 

Since we don't need to retain the names of the outer lists, we can use `unlist(loaded.corpus, use.names = FALSE)`, which performs much more quickly (on my corpus, runs in seconds instead of minutes).