### PR TITLE
Rolling classify ignores user-defined milestone.points

### DIFF
--- a/R/rolling.classify.r
+++ b/R/rolling.classify.r
@@ -555,7 +555,9 @@ corpus.of.secondary.set = load.corpus.and.parse(files=filenames.secondary.set,
                            sampling = "no.sampling"
                            )
 
-milestone.points = grep("xmilestone", corpus.of.secondary.set[[1]])
+if (is.null(milestone.points)) {
+	milestone.points = grep("xmilestone", corpus.of.secondary.set[[1]])
+}
 text.length = length(corpus.of.secondary.set[[1]])
 
 


### PR DESCRIPTION
There's an argument to `rolling.classify()` that allows the user to define a custom set of milestone points to label a chart. This argument is ignored by the function, which searches for instances of the "xmilestone" string in the text file. The function should instead check to see whether the user has defined a set of milestone points before searching the file for this string.