### PR TITLE
set stringsAsFactors=TRUE for COOR data.frame

### DIFF
--- a/R/stylo.R
+++ b/R/stylo.R
@@ -1358,7 +1358,7 @@ if(analysis.type == "PCV" || analysis.type == "PCR") {
       for (c in rownames(pca.results$x)){
         labels = c(labels, gsub("_.*", "", c))
       }
-      COOR = data.frame(pca.results$x[,1:2], LABEL = labels)
+      COOR = data.frame(pca.results$x[,1:2], LABEL = labels, stringsAsFactors = TRUE)
       labels = c(levels(COOR$LABEL))
       # visualize
       sps = trellis.par.get("superpose.symbol")


### PR DESCRIPTION
To maintain compatibility with R versions after 4.0, explicitly call the option `stringsAsFactors=TRUE` in data frames that expect one column to contain factors. 

This patch addresses #43 but the approach may also apply elsewhere in stylo's code.