### PR TITLE
Add headless mode to support wasm compilation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,9 +12,9 @@ Author: Maciej Eder [aut, cre], Jan Rybicki [aut], Mike Kestemont [aut], Steffen
 Maintainer: Maciej Eder <maciejeder@gmail.com>
 URL: https://github.com/computationalstylistics/stylo
 Depends: R (>= 3.0)
-Imports: tcltk, tcltk2, ape, pamr, e1071, class, lattice, tsne
-Suggests: stringi, networkD3, readr
+Imports: ape, pamr, e1071, class, lattice, tsne
+Suggests: tcltk2, stringi, networkD3, readr, testthat
+Config/testthat/edition: 3
 Description: Supervised and unsupervised multivariate methods, supplemented by GUI and some visualizations, to perform various analyses in the field of computational stylistics, authorship attribution, etc. For further reference, see Eder et al. (2016), <https://journal.r-project.org/archive/2016/RJ-2016-007/index.html>. You are also encouraged to visit the Computational Stylistics Group's website <https://computationalstylistics.github.io/>, where a reasonable amount of information about the package and related projects are provided.
 License: GPL (>= 3)
-
 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,8 +1,6 @@
 
 
 import(
-  tcltk,
-  tcltk2, 
   ape, 
   pamr, 
   e1071, 
@@ -82,5 +80,4 @@ S3method(print, stylo.data)
 S3method(summary, stylo.results)
 S3method(summary, stylo.corpus)
 S3method(plot, sample.size)
-
 

--- a/R/classify.R
+++ b/R/classify.R
@@ -65,9 +65,7 @@ variables = stylo.default.settings(...)
 if (gui == TRUE) {
       # first, checking if the GUI can be displayed
       # (the conditional expression is stolen form the generic function "menu")
-      if (.Platform$OS.type == "windows" || .Platform$GUI ==
-            "AQUA" || (capabilities("tcltk") && capabilities("X11") &&
-            suppressWarnings(tcltk::.TkUp))) {
+      if (.stylo_gui_available()) {
         variables = gui.classify(...)
       } else {
         message("")
@@ -514,7 +512,16 @@ if(corpus.exists == FALSE) {
   # Checking whether required files and subdirectories exist
   # First check: allow user to choose a suitable folder via GUI
   if(file.exists(training.corpus.dir) == FALSE | file.exists(test.corpus.dir) == FALSE) {
-    selected.path = tk_choose.dir(caption = "Select your working directory. It should two subdirectories called *primary_set* and *secondary_set*")
+    selected.path = .stylo_choose_dir(
+      caption = "Select your working directory. It should two subdirectories called *primary_set* and *secondary_set*",
+      error_message = paste0(
+        "Working directory should contain two subdirectories: \"",
+        training.corpus.dir,
+        "\" and \"",
+        test.corpus.dir,
+        "\". Pass `path` to a directory containing them."
+      )
+    )
     setwd(selected.path)
   }
   

--- a/R/gui.classify.R
+++ b/R/gui.classify.R
@@ -12,6 +12,7 @@
 
 
 gui.classify = function(...) {
+  .stylo_require_gui("gui.classify()")
   
 
 

--- a/R/gui.oppose.R
+++ b/R/gui.oppose.R
@@ -11,6 +11,7 @@
 
 gui.oppose <-
 function(...) {
+  .stylo_require_gui("gui.oppose()")
   
   # loading required library  #### it will not be needed
   #  library(tcltk2)

--- a/R/gui.stylo.R
+++ b/R/gui.stylo.R
@@ -9,6 +9,7 @@
 # #################################################    
 
 gui.stylo = function(...) {
+  .stylo_require_gui("gui.stylo()")
   
   # loading required libraries
   # (this will be obsolete when we solve the varibles import/export issues)

--- a/R/gui.support.R
+++ b/R/gui.support.R
@@ -1,0 +1,193 @@
+.stylo_has_namespace <- function(pkg) {
+  requireNamespace(pkg, quietly = TRUE)
+}
+
+.stylo_namespace_function <- function(pkg, name) {
+  if (!.stylo_has_namespace(pkg)) {
+    stop(
+      "Optional package `", pkg, "` is required for this stylo GUI operation.",
+      call. = FALSE
+    )
+  }
+
+  get(name, envir = asNamespace(pkg), inherits = FALSE)
+}
+
+.stylo_tk_available <- function() {
+  if (!.stylo_has_namespace("tcltk")) {
+    return(FALSE)
+  }
+
+  if (.Platform$OS.type == "windows" || identical(.Platform$GUI, "AQUA")) {
+    return(TRUE)
+  }
+
+  isTRUE(capabilities("tcltk")) &&
+    isTRUE(capabilities("X11")) &&
+    isTRUE(suppressWarnings(.stylo_namespace_function("tcltk", ".TkUp")))
+}
+
+.stylo_gui_available <- function() {
+  .stylo_tk_available() && .stylo_has_namespace("tcltk2")
+}
+
+.stylo_require_gui <- function(function_name = "This function") {
+  if (.stylo_gui_available()) {
+    return(invisible(TRUE))
+  }
+
+  missing_packages <- character()
+
+  if (!.stylo_has_namespace("tcltk")) {
+    missing_packages <- c(missing_packages, "tcltk")
+  }
+  if (!.stylo_has_namespace("tcltk2")) {
+    missing_packages <- c(missing_packages, "tcltk2")
+  }
+
+  if (length(missing_packages) > 0) {
+    stop(
+      function_name,
+      " requires optional GUI support; missing packages: ",
+      paste(missing_packages, collapse = ", "),
+      ".",
+      call. = FALSE
+    )
+  }
+
+  stop(
+    function_name,
+    " requires an interactive Tcl/Tk session.",
+    call. = FALSE
+  )
+}
+
+.stylo_dialogs_available <- function() {
+  interactive() && .stylo_tk_available()
+}
+
+.stylo_choose_dir <- function(caption, error_message) {
+  if (!.stylo_dialogs_available()) {
+    stop(error_message, call. = FALSE)
+  }
+
+  selected.path <- tk_choose.dir(caption = caption)
+
+  if (!is.character(selected.path) || length(selected.path) == 0 ||
+      is.na(selected.path) || !nzchar(selected.path)) {
+    stop(error_message, call. = FALSE)
+  }
+
+  selected.path
+}
+
+.stylo_choose_files <- function(default = "", caption = "", multi = FALSE,
+                                error_message) {
+  if (!.stylo_dialogs_available()) {
+    stop(error_message, call. = FALSE)
+  }
+
+  selected.files <- tk_choose.files(
+    default = default,
+    caption = caption,
+    multi = multi
+  )
+
+  if (length(selected.files) == 0) {
+    stop(error_message, call. = FALSE)
+  }
+
+  selected.files
+}
+
+.Tcl <- function(...) {
+  .stylo_namespace_function("tcltk", ".Tcl")(...)
+}
+
+tclVar <- function(...) {
+  .stylo_namespace_function("tcltk", "tclVar")(...)
+}
+
+tclvalue <- function(...) {
+  .stylo_namespace_function("tcltk", "tclvalue")(...)
+}
+
+`tclvalue<-` <- function(x, value) {
+  .stylo_namespace_function("tcltk", "tclvalue<-")(x, value)
+}
+
+tktoplevel <- function(...) {
+  .stylo_namespace_function("tcltk", "tktoplevel")(...)
+}
+
+tktitle <- function(...) {
+  .stylo_namespace_function("tcltk", "tktitle")(...)
+}
+
+`tktitle<-` <- function(x, value) {
+  .stylo_namespace_function("tcltk", "tktitle<-")(x, value)
+}
+
+tkdestroy <- function(...) {
+  .stylo_namespace_function("tcltk", "tkdestroy")(...)
+}
+
+tkradiobutton <- function(...) {
+  .stylo_namespace_function("tcltk", "tkradiobutton")(...)
+}
+
+tkconfigure <- function(...) {
+  .stylo_namespace_function("tcltk", "tkconfigure")(...)
+}
+
+tklabel <- function(...) {
+  .stylo_namespace_function("tcltk", "tklabel")(...)
+}
+
+tkcheckbutton <- function(...) {
+  .stylo_namespace_function("tcltk", "tkcheckbutton")(...)
+}
+
+tkentry <- function(...) {
+  .stylo_namespace_function("tcltk", "tkentry")(...)
+}
+
+tkbutton <- function(...) {
+  .stylo_namespace_function("tcltk", "tkbutton")(...)
+}
+
+tkbind <- function(...) {
+  .stylo_namespace_function("tcltk", "tkbind")(...)
+}
+
+tkgrid <- function(...) {
+  .stylo_namespace_function("tcltk", "tkgrid")(...)
+}
+
+`tkgrid.forget` <- function(...) {
+  .stylo_namespace_function("tcltk", "tkgrid.forget")(...)
+}
+
+tkframe <- function(...) {
+  .stylo_namespace_function("tcltk", "tkframe")(...)
+}
+
+`tkwait.window` <- function(...) {
+  .stylo_namespace_function("tcltk", "tkwait.window")(...)
+}
+
+ttkcombobox <- function(...) {
+  .stylo_namespace_function("tcltk", "ttkcombobox")(...)
+}
+
+`tk_choose.dir` <- function(...) {
+  .stylo_namespace_function("tcltk", "tk_choose.dir")(...)
+}
+
+`tk_choose.files` <- function(...) {
+  .stylo_namespace_function("tcltk", "tk_choose.files")(...)
+}
+
+tk2tip <- function(...) {
+  .stylo_namespace_function("tcltk2", "tk2tip")(...)
+}

--- a/R/oppose.R
+++ b/R/oppose.R
@@ -72,9 +72,7 @@ stage.II.similarity.test = TRUE
 if (gui == TRUE) {
       # first, checking if the GUI can be displayed
       # (the conditional expression is stolen form the generic function "menu")
-      if (.Platform$OS.type == "windows" || .Platform$GUI ==
-            "AQUA" || (capabilities("tcltk") && capabilities("X11") &&
-            suppressWarnings(tcltk::.TkUp))) {
+      if (.stylo_gui_available()) {
         variables = gui.oppose(...)
       } else {
         message("")
@@ -290,7 +288,16 @@ if(corpus.exists == FALSE) {
   # Checking whether required files and subdirectories exist
   # First check: allow user to choose a suitable folder via GUI
   if(file.exists(primary.corpus.dir) == FALSE | file.exists(secondary.corpus.dir) == FALSE) {
-    selected.path = tk_choose.dir(caption = "Select your working directory. It should two subdirectories called *primary_set* and *secondary_set*")
+    selected.path = .stylo_choose_dir(
+      caption = "Select your working directory. It should two subdirectories called *primary_set* and *secondary_set*",
+      error_message = paste0(
+        "Working directory should contain two subdirectories: \"",
+        primary.corpus.dir,
+        "\" and \"",
+        secondary.corpus.dir,
+        "\". Pass `path` to a directory containing them."
+      )
+    )
     setwd(selected.path)
   }
 

--- a/R/rolling.classify.r
+++ b/R/rolling.classify.r
@@ -61,8 +61,11 @@ if(is.character(path) == TRUE & length(path) > 0) {
 # Just a few lines that allow users to choose the working directory if working
 # with the GUI.
 
-if(gui == TRUE & is.null(path)){
-  selected.path = tk_choose.dir(caption = "Select your working directory. It should a subdirectory called *corpus* ")
+if(gui == TRUE & is.null(path) & .stylo_dialogs_available()){
+  selected.path = .stylo_choose_dir(
+    caption = "Select your working directory. It should a subdirectory called *corpus* ",
+    error_message = "Working directory selection requires Tcl/Tk."
+  )
   setwd(selected.path)
 }
 
@@ -89,9 +92,7 @@ variables = stylo.default.settings(...)
 if (gui == TRUE) {
       # first, checking if the GUI can be displayed
       # (the conditional expression is stolen form the generic function "menu")
-      if (.Platform$OS.type == "windows" || .Platform$GUI ==
-            "AQUA" || (capabilities("tcltk") && capabilities("X11") &&
-            suppressWarnings(tcltk::.TkUp))) {
+      if (.stylo_gui_available()) {
         #variables = gui.classify(...)
         message("")
         message("GUI could not be launched -- it is not supported yet :-( ")

--- a/R/rolling.delta.R
+++ b/R/rolling.delta.R
@@ -35,8 +35,11 @@ cat("using current directory...\n")
 # Just a few lines that allow users to choose the working directory if working
 # with the GUI.
 
-if(gui == TRUE & is.null(path)){
-  selected.path = tk_choose.dir(caption = "Select your working directory. It should a subdirectory called *corpus* ")
+if(gui == TRUE & is.null(path) & .stylo_dialogs_available()){
+  selected.path = .stylo_choose_dir(
+    caption = "Select your working directory. It should a subdirectory called *corpus* ",
+    error_message = "Working directory selection requires Tcl/Tk."
+  )
   setwd(selected.path)
 }
 
@@ -85,7 +88,13 @@ col12="orange"
 # will serve as default for the GUI for the first run of the script on a corpus.
 # In the subsequent runs, last values will appear as default in the GUI.
 
-interactive.mode.with.GUI = TRUE
+interactive.mode.with.GUI = gui && .stylo_gui_available()
+
+if (gui == TRUE && interactive.mode.with.GUI == FALSE) {
+  message("")
+  message("GUI could not be launched -- default settings will be used;")
+  message("otherwise please pass your variables as command-line agruments.")
+}
 
 ##############################################################################
 

--- a/R/stylo.R
+++ b/R/stylo.R
@@ -65,9 +65,7 @@ variables = stylo.default.settings(...)
 if (gui == TRUE) {
       # first, checking if the GUI can be displayed
       # (the conditional expression is stolen form the generic function "menu")
-      if (.Platform$OS.type == "windows" || .Platform$GUI ==
-            "AQUA" || (capabilities("tcltk") && capabilities("X11") &&
-            suppressWarnings(tcltk::.TkUp))) {
+      if (.stylo_gui_available()) {
         variables = gui.stylo(...)
       } else {
         message(" ")
@@ -528,7 +526,14 @@ if(corpus.exists == FALSE) {
 
   # Checking whether the required subdirectory exists, calling the choose directory dialogue if not.
   if(file.exists(corpus.dir) == FALSE) {
-    selected.path = tk_choose.dir(caption = "Select your working directory. It should have a subdirectory called *corpus* ")
+    selected.path = .stylo_choose_dir(
+      caption = "Select your working directory. It should have a subdirectory called *corpus* ",
+      error_message = paste0(
+        "Working directory should contain the subdirectory \"",
+        corpus.dir,
+        "\". Pass `path` to a directory containing it."
+      )
+    )
     setwd(selected.path)
   }
   if(file.exists(corpus.dir) == FALSE) {
@@ -547,8 +552,16 @@ if(corpus.exists == FALSE) {
   if (interactive.files == TRUE) {
     # go to corpus directory
     setwd(corpus.dir)
-    corpus.filenames = basename(tk_choose.files(default = "",
-                                caption = "Select at least 2 files", multi = TRUE))
+    corpus.filenames = basename(.stylo_choose_files(
+      default = "",
+      caption = "Select at least 2 files",
+      multi = TRUE,
+      error_message = paste0(
+        "Interactive file selection requires Tcl/Tk. Set `interactive.files = FALSE` or provide files in `",
+        corpus.dir,
+        "`."
+      )
+    ))
     # back to the working directory
     setwd("..")
   } else {

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(stylo)
+
+test_check("stylo")

--- a/tests/testthat/helper-fixtures.R
+++ b/tests/testthat/helper-fixtures.R
@@ -1,0 +1,20 @@
+make_test_root <- function() {
+  root <- tempfile("stylo-test-")
+  dir.create(root)
+  root
+}
+
+write_test_corpus <- function(root, dir_name = "corpus", n_files = 2,
+                              n_words = 20) {
+  corpus_path <- file.path(root, dir_name)
+  dir.create(corpus_path, recursive = TRUE, showWarnings = FALSE)
+
+  for (idx in seq_len(n_files)) {
+    file_name <- sprintf("author%d_sample%d.txt", idx, idx)
+    file_path <- file.path(corpus_path, file_name)
+    file_text <- paste(rep(sprintf("token%d", idx), n_words), collapse = " ")
+    writeLines(file_text, file_path)
+  }
+
+  corpus_path
+}

--- a/tests/testthat/test-batch-mode.R
+++ b/tests/testthat/test-batch-mode.R
@@ -1,0 +1,41 @@
+test_that("stylo batch mode works with built-in frequency data", {
+  data("lee", package = "stylo")
+  root <- make_test_root()
+
+  result <- suppressMessages(stylo(
+    gui = FALSE,
+    path = root,
+    frequencies = lee,
+    display.on.screen = FALSE,
+    write.pdf.file = FALSE,
+    write.jpg.file = FALSE,
+    write.svg.file = FALSE,
+    write.png.file = FALSE
+  ))
+
+  expect_s3_class(result, "stylo.results")
+})
+
+test_that("stylo(gui = TRUE) falls back cleanly when GUI support is unavailable", {
+  data("lee", package = "stylo")
+  root <- make_test_root()
+
+  testthat::local_mocked_bindings(
+    .stylo_gui_available = function() FALSE,
+    gui.stylo = function(...) stop("unexpected gui call"),
+    .package = "stylo"
+  )
+
+  result <- suppressMessages(stylo(
+    gui = TRUE,
+    path = root,
+    frequencies = lee,
+    display.on.screen = FALSE,
+    write.pdf.file = FALSE,
+    write.jpg.file = FALSE,
+    write.svg.file = FALSE,
+    write.png.file = FALSE
+  ))
+
+  expect_s3_class(result, "stylo.results")
+})

--- a/tests/testthat/test-headless-errors.R
+++ b/tests/testthat/test-headless-errors.R
@@ -1,0 +1,52 @@
+test_that("gui.stylo() reports missing optional GUI support cleanly", {
+  testthat::local_mocked_bindings(
+    .stylo_gui_available = function() FALSE,
+    .stylo_has_namespace = function(pkg) pkg != "tcltk2",
+    .package = "stylo"
+  )
+
+  expect_error(gui.stylo(), "missing packages: tcltk2", fixed = TRUE)
+})
+
+test_that("stylo reports a plain error instead of opening a directory chooser", {
+  root <- make_test_root()
+
+  testthat::local_mocked_bindings(
+    .stylo_dialogs_available = function() FALSE,
+    tk_choose.dir = function(...) stop("unexpected chooser"),
+    .package = "stylo"
+  )
+
+  expect_error(
+    stylo(
+      gui = FALSE,
+      path = root,
+      corpus.dir = "missing-corpus",
+      interactive.files = FALSE
+    ),
+    "Working directory should contain the subdirectory",
+    fixed = TRUE
+  )
+})
+
+test_that("stylo reports a plain error instead of opening a file chooser", {
+  root <- make_test_root()
+  write_test_corpus(root, dir_name = "corpus")
+
+  testthat::local_mocked_bindings(
+    .stylo_dialogs_available = function() FALSE,
+    tk_choose.files = function(...) stop("unexpected chooser"),
+    .package = "stylo"
+  )
+
+  expect_error(
+    stylo(
+      gui = FALSE,
+      path = root,
+      corpus.dir = "corpus",
+      interactive.files = TRUE
+    ),
+    "Interactive file selection requires Tcl/Tk.",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-rolling-delta.R
+++ b/tests/testthat/test-rolling-delta.R
@@ -1,0 +1,14 @@
+test_that("rolling.delta(gui = FALSE) does not enter GUI code", {
+  root <- make_test_root()
+
+  testthat::local_mocked_bindings(
+    .Tcl = function(...) stop("unexpected gui call"),
+    .package = "stylo"
+  )
+
+  expect_error(
+    rolling.delta(gui = FALSE, path = root),
+    "Corpus prepared incorrectly",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-supervised-errors.R
+++ b/tests/testthat/test-supervised-errors.R
@@ -1,0 +1,41 @@
+test_that("classify reports a plain error when corpora directories are missing", {
+  root <- make_test_root()
+
+  testthat::local_mocked_bindings(
+    .stylo_dialogs_available = function() FALSE,
+    tk_choose.dir = function(...) stop("unexpected chooser"),
+    .package = "stylo"
+  )
+
+  expect_error(
+    classify(
+      gui = FALSE,
+      path = root,
+      training.corpus.dir = "train-set",
+      test.corpus.dir = "test-set"
+    ),
+    "Working directory should contain two subdirectories",
+    fixed = TRUE
+  )
+})
+
+test_that("oppose reports a plain error when corpora directories are missing", {
+  root <- make_test_root()
+
+  testthat::local_mocked_bindings(
+    .stylo_dialogs_available = function() FALSE,
+    tk_choose.dir = function(...) stop("unexpected chooser"),
+    .package = "stylo"
+  )
+
+  expect_error(
+    oppose(
+      gui = FALSE,
+      path = root,
+      primary.corpus.dir = "primary",
+      secondary.corpus.dir = "secondary"
+    ),
+    "Working directory should contain two subdirectories",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
This commit adds headless support for the package so we can make it usable for [WebR](https://github.com/r-wasm/webr). Since there's no normal desktop environment in wasm, it will currently fail because of the import of the GUI dependencies (`tcltk/tcltk2`).

The changes in this commit:
  - make tcltk2 optional instead of mandatory
  - defer GUI requirements until GUI code is actually called
  - keep batch/headless analysis working without Tk
  - make GUI-related fallback paths fail cleanly instead of trying to open dialogs

I also added some basic tests to confirm this behavior. I considered adding these tests to run automatically in GitHub Actions, but didn't know if that would make the PR to big (but I will happily add that so future PRs automatically have tests run on them, if that would be helpful).