### PR TITLE
Dendrogram: dynamically size margins based on longest label

### DIFF
--- a/R/stylo.R
+++ b/R/stylo.R
@@ -1173,10 +1173,12 @@ plot.current.task = function() {NULL}
 if(analysis.type == "CA") {
   name.of.the.method = "Cluster Analysis"
   short.name.of.the.method = "CA"
+  max.label.chars = max(nchar(rownames(distance.table)))
+  label.margin = max(8, ceiling(max.label.chars * 0.6))
   if(dendrogram.layout.horizontal == TRUE) {
-    dendrogram.margins =  c(5,4,4,8)+0.1
+    dendrogram.margins = c(5, 4, 4, label.margin) + 0.1
     } else {
-    dendrogram.margins = c(8,5,4,4)+0.1 }
+    dendrogram.margins = c(label.margin, 5, 4, 4) + 0.1 }
   # the following task will be plotted
   plot.current.task = function(){
     par(mar=dendrogram.margins)


### PR DESCRIPTION
Fixes #56

The right margin for horizontal dendrograms (and bottom margin for vertical ones) was hardcoded at 8.1 lines regardless of how long the document labels are. When the distance range is small, the dendrogram branches compress toward the left and the labels end up right against the edge of the plot area, getting clipped.

Fixed by calculating the width of the longest label in characters and scaling it to R margin units (roughly 0.6 lines per character), then taking the max of that and 8 so short labels keep the same layout as before. Applies to both horizontal and vertical dendrogram orientations.